### PR TITLE
update checking to fix error

### DIFF
--- a/common/misc.go
+++ b/common/misc.go
@@ -244,7 +244,7 @@ func ValidV2Token(token string) bool {
 	}
 
 	// get payload value, which contains expiry information
-	payload, err := base64.StdEncoding.DecodeString(parts[1])
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
 		log.Println("Error decoding token: ", err.Error())
 		return false


### PR DESCRIPTION
Current checking results in parsing error because of the addition of sub information in the jwt payload which was previously not included. This updated parsing is able to handle this information.