### PR TITLE
update GetMetadataStringVal function

### DIFF
--- a/common/misc.go
+++ b/common/misc.go
@@ -313,6 +313,6 @@ func GenerateMD5(file io.Reader, fileSize, maxSize int64) (hash string, hashSize
 
 // Parses the metadata and returns the value of the specified field
 func GetMetadataStringVal(metadata json.RawMessage, field string) string {
-	value, _ := jsonparser.GetString(metadata, field)
-	return value
+	valueBytes, _, _, _ := jsonparser.Get(metadata, field)
+	return string(valueBytes)
 }


### PR DESCRIPTION
Use Get instead of GetString so that it can also retrieve fields of `int`, `bool`, and other types.
The value returned (valueBytes, in this case) is of type `[]byte` which is then converted to string as the function's return value.